### PR TITLE
parse: Fix whitespace consumption within text nodes

### DIFF
--- a/indent.c
+++ b/indent.c
@@ -207,8 +207,11 @@ static void force_newline_before_tag(struct buffer * buffer)
     buffer_push_char(buffer, current);
 
     if (!is_newline(current)) {
-	do_newline(buffer, "\n");
-	eat_whitespace();
+        do_newline(buffer, "\n");
+        if (is_whitespace(current)) {
+            eat_whitespace();
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
xmlindent was incorrectly consuming whitespace within text nodes.

The following command gave wrong output:
```
  $ echo "<li><strong><em>a glass of water</em></strong></li>" | xmlindent
```
Original-Author: Miriam Ruiz <miriam@debian.org>