### PR TITLE
parse: Don't abort() on parse errors; cope with NULs; handle EOF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 all: xmlindent
 
 PREFIX=/usr/local
+DESTDIR=
 BIN_INSTALL_DIR=$(PREFIX)/bin
 MAN_INSTALL_DIR=$(PREFIX)/share/man/man1
+CFLAGS=-Wall -g
+LDFLAGS=-Wl,-z,defs -Wl,-as-needed -Wl,--no-undefined
 
 xmlindent: buffer.o error.o indent.o main.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ -lfl
@@ -17,16 +20,16 @@ lex.yy.c: xmlindent.yy
 	flex xmlindent.yy
 
 install: xmlindent
-	mkdir -p $(BIN_INSTALL_DIR)
-	mkdir -p $(MAN_INSTALL_DIR)
-	install -m555 xmlindent $(BIN_INSTALL_DIR)/xmlindent
-	install -m444 xmlindent.1 $(MAN_INSTALL_DIR)/xmlindent.1
+	mkdir -p $(DESTDIR)$(BIN_INSTALL_DIR)
+	mkdir -p $(DESTDIR)$(MAN_INSTALL_DIR)
+	install -m555 xmlindent $(DESTDIR)$(BIN_INSTALL_DIR)/xmlindent
+	install -m444 xmlindent.1 $(DESTDIR)$(MAN_INSTALL_DIR)/xmlindent.1
 
 uninstall:
-	rm -f $(BIN_INSTALL_DIR)/xmlindent
-	rm -f $(MAN_INSTALL_DIR)/xmlindent.1
+	rm -f $(DESTDIR)$(BIN_INSTALL_DIR)/xmlindent
+	rm -f $(DESTDIR)$(MAN_INSTALL_DIR)/xmlindent.1
 
 clean:
 	rm -f xmlindent *.o core lex.yy.c
 
-.PHONY: all clean
+.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CFLAGS=-Wall -g
 LDFLAGS=-Wl,-z,defs -Wl,-as-needed -Wl,--no-undefined
 
 xmlindent: buffer.o error.o indent.o main.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ -lfl
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) $^ -c -o $@

--- a/indent.c
+++ b/indent.c
@@ -437,6 +437,17 @@ static bool need_wrap(struct buffer * buffer)
 		+ buffer_size(buffer) + indent_size()) >= max_columns;
 }
 
+/*
+ * We detect EOF by getting a call to yywrap() when the only input file
+ * is completely read.
+ */
+static bool is_at_eof;
+
+int yywrap() {
+    is_at_eof = 1;
+    return 1; /* 1=nothing more to read */
+}
+
 static void content(void)
 {
     char current;
@@ -444,10 +455,10 @@ static void content(void)
     /*
      * We should get one character at a time.
      */
-    assert(strlen(yytext) == 1);
+    assert(yyleng == 1); /* strlen(yytext) fails at NUL or EOF */
 
     current = yytext[0];
-    if (current == EOF)
+    if (is_at_eof)
 	return;
     
     if (is_newline(current)) {

--- a/xmlindent.yy
+++ b/xmlindent.yy
@@ -101,8 +101,8 @@ COMMENT			"<!--"
 }
 
 . {
-	fprintf(stderr, "Error: Scanner did not recognize string '%s'. ", yytext);
-	abort();
+	fprintf(stderr, "Error: Scanner did not recognize string '%s' near line %d.\n", yytext, yylineno);
+	exit(1);
 }
 
 %%


### PR DESCRIPTION
- xmlindent asserted False at EOF:
  content() would be called with a NUL, causing strlen to return non-1. Now
  it handles both inline NULs and doesn't crash.
- xmlindent would abort() at unrecognised tokens. Now it just exit(1)s.